### PR TITLE
fix: change sed command for mac

### DIFF
--- a/context.zsh
+++ b/context.zsh
@@ -1,6 +1,8 @@
 #!/bin/zsh
 
 CONTEXT_FILE=$(find "${SCRIPT_DIR}/.tmp/" -name ".context_${pid}_??????" | head -n 1)
+# Determine the current operating system for platform-specific handling
+OS=$(uname)
 
 # Update the context file
 update_context() {
@@ -14,8 +16,13 @@ update_context() {
 
 # Update the context file with current line buffer
 update_context_buffer() {
-    sed -i '' "1s|.*|$(_zsh_autosuggest_escape_command "${BUFFER:-}")|" "$CONTEXT_FILE"
-    #sed -i "1s/.*/$(printf "%s" "${BUFFER:-}" | sed 's/[\/&]/\\&/g')/" "$CONTEXT_FILE"
+    if [[ "$OS" == "Darwin" ]]; then
+        sed -i '' "1s|.*|$(_zsh_autosuggest_escape_command "${BUFFER:-}")|" "$CONTEXT_FILE"
+        #sed -i '' "1s/.*/$(printf "%s" "${BUFFER:-}" | sed 's/[\/&]/\\&/g')/" "$CONTEXT_FILE"
+    else
+        sed -i "1s|.*|$(_zsh_autosuggest_escape_command "${BUFFER:-}")|" "$CONTEXT_FILE"
+        #sed -i "1s/.*/$(printf "%s" "${BUFFER:-}" | sed 's/[\/&]/\\&/g')/" "$CONTEXT_FILE"
+    fi
 }
 
 

--- a/context.zsh
+++ b/context.zsh
@@ -14,7 +14,7 @@ update_context() {
 
 # Update the context file with current line buffer
 update_context_buffer() {
-    sed -i "1s|.*|$(_zsh_autosuggest_escape_command "${BUFFER:-}")|" "$CONTEXT_FILE"
+    sed -i '' "1s|.*|$(_zsh_autosuggest_escape_command "${BUFFER:-}")|" "$CONTEXT_FILE"
     #sed -i "1s/.*/$(printf "%s" "${BUFFER:-}" | sed 's/[\/&]/\\&/g')/" "$CONTEXT_FILE"
 }
 


### PR DESCRIPTION
see https://github.com/OskarSzafer/open-cli-copilot/issues/3

and https://stackoverflow.com/questions/26081375/bsd-sed-extra-characters-at-the-end-of-d-command

`sed` operates differently on mac and linux. This tiny change should work for both. 